### PR TITLE
Bump up go major version for buildpack

### DIFF
--- a/databases/aws-rds/manifest.yml
+++ b/databases/aws-rds/manifest.yml
@@ -3,7 +3,7 @@ applications:
     buildpacks:
       - go_buildpack
     env:
-      GOVERSION: go1.12
+      GOVERSION: go1.13
       GOPACKAGENAME: aws-rds
       CGO_CFLAGS: -Isrc/github.com/18f/databases/aws-rds/include
       LD_LIBRARY_PATH: "/home/vcap/app/include/oracle:$LD_LIBRARY_PATH"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Bump up the Go Lang version from `1.12` to `1.13`
  - *Note* - Version `1.12` has been removed

## security considerations
None
