### PR TITLE
Bump go version (13 no longer available)

### DIFF
--- a/databases/aws-rds/manifest.yml
+++ b/databases/aws-rds/manifest.yml
@@ -3,7 +3,7 @@ applications:
     buildpacks:
       - go_buildpack
     env:
-      GOVERSION: go1.13
+      GOVERSION: go1.15
       GOPACKAGENAME: aws-rds
       CGO_CFLAGS: -Isrc/github.com/18f/databases/aws-rds/include
       LD_LIBRARY_PATH: "/home/vcap/app/include/oracle:$LD_LIBRARY_PATH"


### PR DESCRIPTION
## Changes proposed in this pull request:

Bumps Go to version 1.15 as 1.13 is no longer available.

## security considerations

None
