### PR TITLE
bump goversion for app to 1.18

### DIFF
--- a/databases/aws-rds/manifest.yml
+++ b/databases/aws-rds/manifest.yml
@@ -3,7 +3,7 @@ applications:
     buildpacks:
       - go_buildpack
     env:
-      GOVERSION: go1.16
+      GOVERSION: go1.18
       GOPACKAGENAME: aws-rds
       CGO_CFLAGS: -Isrc/github.com/18f/databases/aws-rds/include
       LD_LIBRARY_PATH: "/home/vcap/app/include/oracle:$LD_LIBRARY_PATH"


### PR DESCRIPTION
## Changes proposed in this pull request:
- app needs to update to new go version
-
-

## security considerations
none
