### PR TITLE
Update manifest.yml to use go 1.20

### DIFF
--- a/databases/aws-rds/manifest.yml
+++ b/databases/aws-rds/manifest.yml
@@ -3,7 +3,7 @@ applications:
     buildpacks:
       - go_buildpack
     env:
-      GOVERSION: go1.18
+      GOVERSION: go1.20
       GOPACKAGENAME: aws-rds
       CGO_CFLAGS: -Isrc/github.com/18f/databases/aws-rds/include
       LD_LIBRARY_PATH: "/home/vcap/app/include/oracle:$LD_LIBRARY_PATH"


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update Go version from 1.18 to 1.20 because latest buildpacks only support Go 1.19+: https://github.com/cloudfoundry/go-buildpack/releases/tag/v1.10.8

## security considerations

None
