### PR TITLE
changing go version

### DIFF
--- a/databases/aws-rds/manifest.yml
+++ b/databases/aws-rds/manifest.yml
@@ -3,7 +3,7 @@ applications:
     buildpacks:
       - go_buildpack
     env:
-      GOVERSION: go1.20
+      GOVERSION: go1.22
       GOPACKAGENAME: aws-rds
       CGO_CFLAGS: -Isrc/github.com/18f/databases/aws-rds/include
       LD_LIBRARY_PATH: "/home/vcap/app/include/oracle:$LD_LIBRARY_PATH"


### PR DESCRIPTION
## Changes proposed in this pull request:
- V1.22 is more up to date
-
-

## security considerations
none
