### PR TITLE
Remove the `GOVERSION` 

### DIFF
--- a/databases/aws-rds/manifest.yml
+++ b/databases/aws-rds/manifest.yml
@@ -3,7 +3,7 @@ applications:
     buildpacks:
       - go_buildpack
     env:
-      GOVERSION: go1.22
+      #GOVERSION: go1.22
       GOPACKAGENAME: aws-rds
       CGO_CFLAGS: -Isrc/github.com/cloud-gov/databases/aws-rds/include
       LD_LIBRARY_PATH: "/home/vcap/app/include/oracle:$LD_LIBRARY_PATH"

--- a/databases/aws-rds/manifest.yml
+++ b/databases/aws-rds/manifest.yml
@@ -3,7 +3,6 @@ applications:
     buildpacks:
       - go_buildpack
     env:
-      #GOVERSION: go1.22
       GOPACKAGENAME: aws-rds
       CGO_CFLAGS: -Isrc/github.com/cloud-gov/databases/aws-rds/include
       LD_LIBRARY_PATH: "/home/vcap/app/include/oracle:$LD_LIBRARY_PATH"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove the `GOVERSION` to keep from conflicting with buildpack golang version bumps
- Part of https://github.com/cloud-gov/private/issues/2425
-

## security considerations
Removes pinning of golang version to pick up patches
